### PR TITLE
Grimworld-Framework Update:

### DIFF
--- a/Source/ChainProjectiles/ChainProjectile.cs
+++ b/Source/ChainProjectiles/ChainProjectile.cs
@@ -30,6 +30,11 @@ namespace ChainProjectiles
                 return;
             }
 
+            if (verb == null)
+            {
+                return;
+            }
+
             LocalTargetInfo currentTarget = GetNextTarget(hitThing);
             if (!currentTarget.HasThing)
             {
@@ -40,7 +45,7 @@ namespace ChainProjectiles
 
             projectile2.hitThings = hitThings;
             projectile2.hitThings.Add(hitThing);
-            projectile2.chainLeft = ChainLeft;
+            projectile2.chainLeft = ChainLeft - 1;
             projectile2.verb = verb;
 
             if (verb == null)
@@ -272,7 +277,7 @@ namespace ChainProjectiles
 
             ImpactSomething();
 
-            Log.Warning("launched with ChainLeft: " + ChainLeft + ", verb: " + verb + ", hitThings count: " + hitThings.Count + ", ChainRange: " + ChainRange);
+            //Log.Warning("launched with ChainLeft: " + ChainLeft + ", verb: " + verb + ", hitThings count: " + hitThings.Count + ", ChainRange: " + ChainRange);
         }
     }
 }

--- a/Source/ChainProjectiles/ChainProjectiles.csproj
+++ b/Source/ChainProjectiles/ChainProjectiles.csproj
@@ -1,55 +1,28 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{D651124A-CA3A-4369-B895-23F51733DB3F}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>ChainProjectiles</RootNamespace>
+    <TargetFramework>net472</TargetFramework>
     <AssemblyName>ChainProjectiles</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <RootNamespace>ChainProjectiles</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <OutputPath>..\..\..\..\1.6\Assemblies\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(RimworldPath)\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(RimworldPath)\RimWorldWin64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ChainProjectile.cs" />
-    <Compile Include="ChainProjectileModExtension.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
 </Project>


### PR DESCRIPTION
- ChainProjectiles — Bug Fixes
  - Fixed: Chain bounces were unlimited. chainLeft was copied to each spawned projectile without decrementing, so the chainMaxCount limit was never enforced. The Tesla Carbine would chain to every reachable target on the map instead of stopping after the configured number of bounces.
  - Fixed: NullReferenceException when verb is unresolved. If the initial projectile launch failed to resolve its firing verb, Impact would proceed into GetNextTarget and crash on verb.CasterPawn. Added a null guard to abort chaining cleanly.
  - Removed debug logging. Log.Warning(...) in ChainProjectile.Launch was left in from development and fired on every single bounce, flooding the log with hundreds of entries per shot.